### PR TITLE
define sound context to fix example

### DIFF
--- a/3s/tests/example.rkt
+++ b/3s/tests/example.rkt
@@ -11,6 +11,7 @@
     (parameterize ([current-custodian new-custodian])
       (thread
        (lambda ()
+         (define sc (make-sound-context))
          (define track1 (path->audio track1-pth))
          (displayln "T Initializing")
          (define ss0 (initial-system-state sc))


### PR DESCRIPTION
Currently, the provided example does not compile because the variable `sc` is undefined inside the body of the `go!` function.

This pr defines the variable `sc`, binding it to a sound context.